### PR TITLE
[backend][frontend] EL023: JQL-парсер для фильтрации задач

### DIFF
--- a/backend/alembic/versions/j1q2l3p4a5r6_add_saved_filters.py
+++ b/backend/alembic/versions/j1q2l3p4a5r6_add_saved_filters.py
@@ -1,0 +1,40 @@
+"""Add saved_filters table for JQL.
+
+Revision ID: j1q2l3p4a5r6
+Revises: n1o2t3i4f5y6
+Create Date: 2026-03-11
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+# revision identifiers
+revision = "j1q2l3p4a5r6"
+down_revision = "n1o2t3i4f5y6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    tables = inspector.get_table_names()
+
+    if "saved_filters" not in tables:
+        op.create_table(
+            "saved_filters",
+            sa.Column("id", sa.String(36), primary_key=True),
+            sa.Column("owner_id", sa.String(36), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+            sa.Column("project_id", sa.String(36), sa.ForeignKey("projects.id", ondelete="CASCADE"), nullable=False),
+            sa.Column("name", sa.String(100), nullable=False),
+            sa.Column("jql", sa.Text, nullable=False),
+            sa.Column("is_shared", sa.Boolean, default=False),
+            sa.Column("created_at", sa.DateTime, default=sa.func.now()),
+            sa.Column("updated_at", sa.DateTime, nullable=True),
+            sa.UniqueConstraint("owner_id", "project_id", "name", name="uq_saved_filter_owner_project_name"),
+        )
+
+
+def downgrade() -> None:
+    op.drop_table("saved_filters")

--- a/backend/app/jql/__init__.py
+++ b/backend/app/jql/__init__.py
@@ -1,0 +1,20 @@
+"""JQL — Jira Query Language parser and compiler for ErrorLens."""
+
+from app.jql.compiler import JQLCompiler, JQLContext
+from app.jql.exceptions import (
+    JQLError,
+    JQLFieldError,
+    JQLFunctionError,
+    JQLSyntaxError,
+    JQLValueError,
+)
+
+__all__ = [
+    "JQLCompiler",
+    "JQLContext",
+    "JQLError",
+    "JQLFieldError",
+    "JQLFunctionError",
+    "JQLSyntaxError",
+    "JQLValueError",
+]

--- a/backend/app/jql/compiler.py
+++ b/backend/app/jql/compiler.py
@@ -1,0 +1,403 @@
+"""JQL Compiler — parse JQL string and produce SQLAlchemy WHERE clause."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from lark import Lark, Token, Tree, UnexpectedInput
+from sqlalchemy import and_, not_, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.jql.exceptions import (
+    JQLFieldError,
+    JQLFunctionError,
+    JQLSyntaxError,
+    JQLValueError,
+)
+from app.jql.fields import (
+    FIELD_REGISTRY,
+    FieldDescriptor,
+    resolve_field,
+)
+from app.models.db_models import Task, TaskActivity
+
+_GRAMMAR_PATH = Path(__file__).parent / "grammar.lark"
+_parser: Lark | None = None
+
+
+def _get_parser() -> Lark:
+    global _parser
+    if _parser is None:
+        _parser = Lark(
+            _GRAMMAR_PATH.read_text(encoding="utf-8"),
+            parser="earley",
+            ambiguity="resolve",
+        )
+    return _parser
+
+
+# --- Relative date parsing ---
+_REL_DATE_RE = re.compile(r"^([+-])(\d+)([dwhmDWHM])$")
+_UNIT_MAP = {"d": "days", "w": "weeks", "h": "hours", "m": "minutes"}
+
+
+def _parse_relative_date(token: str) -> datetime:
+    m = _REL_DATE_RE.match(token)
+    if not m:
+        raise JQLValueError("date", token)
+    sign, amount, unit = m.group(1), int(m.group(2)), m.group(3).lower()
+    delta = timedelta(**{_UNIT_MAP[unit]: amount})
+    if sign == "-":
+        return datetime.utcnow() - delta
+    return datetime.utcnow() + delta
+
+
+# --- Known functions ---
+_KNOWN_FUNCTIONS = {
+    "currentuser", "now", "startofday", "endofday",
+    "startofweek", "startofmonth", "membersof",
+}
+
+
+@dataclass
+class JQLContext:
+    """Runtime context for JQL compilation."""
+
+    current_user_id: str
+    project_id: str | None = None
+    db: AsyncSession | None = None
+
+
+@dataclass
+class JQLResult:
+    """Compilation result."""
+
+    where_clause: Any  # SQLAlchemy BooleanClauseList
+    order_clauses: list[Any] = field(default_factory=list)
+
+
+class JQLCompiler:
+    """Compile JQL string → SQLAlchemy WHERE clause."""
+
+    def __init__(self) -> None:
+        self._lookup_cache: dict[tuple[str, str], str | None] = {}
+
+    async def compile(self, jql: str, context: JQLContext) -> JQLResult:
+        """Parse and compile JQL string."""
+        self._context = context
+        self._lookup_cache.clear()
+
+        try:
+            tree = _get_parser().parse(jql)
+        except UnexpectedInput as e:
+            raise JQLSyntaxError(
+                message=str(e),
+                position=getattr(e, "pos_in_stream", None),
+                line=getattr(e, "line", None),
+            ) from e
+
+        return await self._visit_query(tree)
+
+    def parse_only(self, jql: str) -> Tree:
+        """Parse JQL without compilation (for validation)."""
+        try:
+            return _get_parser().parse(jql)
+        except UnexpectedInput as e:
+            raise JQLSyntaxError(
+                message=str(e),
+                position=getattr(e, "pos_in_stream", None),
+                line=getattr(e, "line", None),
+            ) from e
+
+    # --- Tree visitors ---
+
+    async def _visit_query(self, tree: Tree) -> JQLResult:
+        result = JQLResult(where_clause=None)
+        for child in tree.children:
+            if isinstance(child, Tree):
+                if child.data == "query":
+                    return await self._visit_query(child)
+                elif child.data == "order_by":
+                    result.order_clauses = await self._visit_order_by(child)
+                else:
+                    result.where_clause = await self._visit(child)
+        return result
+
+    async def _visit(self, node: Tree | Token) -> Any:
+        if isinstance(node, Token):
+            return node
+
+        handler = getattr(self, f"_visit_{node.data}", None)
+        if handler:
+            return await handler(node)
+
+        # Generic: AND/OR chain detection
+        children = [c for c in node.children if isinstance(c, Tree)]
+        if len(children) == 1:
+            return await self._visit(children[0])
+
+        # Default: visit all children and AND them
+        clauses = []
+        for child in node.children:
+            if isinstance(child, Tree):
+                clauses.append(await self._visit(child))
+        if len(clauses) == 1:
+            return clauses[0]
+        return and_(*clauses) if clauses else True
+
+    async def _visit_or_expr(self, node: Tree) -> Any:
+        clauses = []
+        for child in node.children:
+            if isinstance(child, Tree):
+                clauses.append(await self._visit(child))
+        if len(clauses) == 1:
+            return clauses[0]
+        return or_(*clauses)
+
+    async def _visit_and_expr(self, node: Tree) -> Any:
+        clauses = []
+        for child in node.children:
+            if isinstance(child, Tree):
+                clauses.append(await self._visit(child))
+        if len(clauses) == 1:
+            return clauses[0]
+        return and_(*clauses)
+
+    async def _visit_not_clause(self, node: Tree) -> Any:
+        child = next(c for c in node.children if isinstance(c, Tree))
+        return not_(await self._visit(child))
+
+    async def _visit_comparison(self, node: Tree) -> Any:
+        field_name = self._extract_field(node)
+        op = self._extract_op(node)
+        value = await self._extract_value(node, field_name)
+        canonical, desc = resolve_field(field_name)
+        column = desc.column
+        resolved = await self._resolve_value(canonical, desc, value)
+
+        ops = {
+            "=": lambda c, v: c == v,
+            "!=": lambda c, v: c != v,
+            "<": lambda c, v: c < v,
+            ">": lambda c, v: c > v,
+            "<=": lambda c, v: c <= v,
+            ">=": lambda c, v: c >= v,
+        }
+        return ops[op](column, resolved)
+
+    async def _visit_in_condition(self, node: Tree) -> Any:
+        field_name = self._extract_field(node)
+        values = await self._extract_value_list(node, field_name)
+        canonical, desc = resolve_field(field_name)
+        resolved = [await self._resolve_value(canonical, desc, v) for v in values]
+        return desc.column.in_(resolved)
+
+    async def _visit_not_in_condition(self, node: Tree) -> Any:
+        field_name = self._extract_field(node)
+        values = await self._extract_value_list(node, field_name)
+        canonical, desc = resolve_field(field_name)
+        resolved = [await self._resolve_value(canonical, desc, v) for v in values]
+        return desc.column.notin_(resolved)
+
+    async def _visit_is_empty(self, node: Tree) -> Any:
+        field_name = self._extract_field(node)
+        _, desc = resolve_field(field_name)
+        return desc.column.is_(None)
+
+    async def _visit_is_not_empty(self, node: Tree) -> Any:
+        field_name = self._extract_field(node)
+        _, desc = resolve_field(field_name)
+        return desc.column.isnot(None)
+
+    async def _visit_contains_condition(self, node: Tree) -> Any:
+        field_name = self._extract_field(node)
+        value = await self._extract_value(node, field_name)
+        canonical, desc = resolve_field(field_name)
+
+        if desc.is_text_search:
+            pattern = f"%{value}%"
+            return or_(
+                Task.title.ilike(pattern),
+                Task.description.ilike(pattern),
+            )
+        return desc.column.ilike(f"%{value}%")
+
+    async def _visit_not_contains_condition(self, node: Tree) -> Any:
+        field_name = self._extract_field(node)
+        value = await self._extract_value(node, field_name)
+        canonical, desc = resolve_field(field_name)
+
+        if desc.is_text_search:
+            pattern = f"%{value}%"
+            return and_(
+                not_(Task.title.ilike(pattern)),
+                not_(Task.description.ilike(pattern)),
+            )
+        return not_(desc.column.ilike(f"%{value}%"))
+
+    async def _visit_was_condition(self, node: Tree) -> Any:
+        field_name = self._extract_field(node)
+        canonical, desc = resolve_field(field_name)
+        if not desc.supports_history:
+            raise JQLFieldError(f"{field_name} does not support WAS operator")
+        value = await self._extract_value(node, field_name)
+        resolved = await self._resolve_value(canonical, desc, value)
+
+        subq = (
+            select(TaskActivity.task_id)
+            .where(
+                TaskActivity.field_name == canonical,
+                TaskActivity.old_value[canonical].as_string() == str(resolved),
+            )
+        )
+        return Task.id.in_(subq)
+
+    async def _visit_changed_condition(self, node: Tree) -> Any:
+        field_name = self._extract_field(node)
+        canonical, desc = resolve_field(field_name)
+        if not desc.supports_history:
+            raise JQLFieldError(f"{field_name} does not support CHANGED operator")
+
+        subq = (
+            select(TaskActivity.task_id)
+            .where(TaskActivity.field_name == canonical)
+        )
+        return Task.id.in_(subq)
+
+    async def _visit_order_by(self, node: Tree) -> list:
+        clauses = []
+        for child in node.children:
+            if isinstance(child, Tree) and child.data == "order_field":
+                field_name = self._extract_field(child)
+                _, desc = resolve_field(field_name)
+                col = desc.column
+                direction = "asc"
+                for token in child.children:
+                    if isinstance(token, Token):
+                        if token.type in ("ASC", "DESC"):
+                            direction = str(token).lower()
+                clauses.append(col.asc() if direction == "asc" else col.desc())
+        return clauses
+
+    # --- Helpers ---
+
+    def _extract_field(self, node: Tree) -> str:
+        for child in node.children:
+            if isinstance(child, Tree) and child.data == "field":
+                return str(child.children[0]).strip()
+            if isinstance(child, Token) and child.type == "FIELD_NAME":
+                return str(child).strip()
+        raise JQLSyntaxError("Missing field name")
+
+    def _extract_op(self, node: Tree) -> str:
+        for child in node.children:
+            if isinstance(child, Tree) and child.data == "op":
+                return str(child.children[0]).strip()
+            if isinstance(child, Token) and child.type == "OP":
+                return str(child).strip()
+        raise JQLSyntaxError("Missing operator")
+
+    async def _extract_value(self, node: Tree, field_name: str) -> Any:
+        for child in node.children:
+            if isinstance(child, Tree) and child.data == "value":
+                return await self._resolve_raw_value(child)
+        raise JQLSyntaxError(f"Missing value for field {field_name}")
+
+    async def _extract_value_list(self, node: Tree, field_name: str) -> list:
+        for child in node.children:
+            if isinstance(child, Tree) and child.data == "value_list":
+                values = []
+                for vc in child.children:
+                    if isinstance(vc, Tree) and vc.data == "value":
+                        values.append(await self._resolve_raw_value(vc))
+                return values
+        raise JQLSyntaxError(f"Missing value list for field {field_name}")
+
+    async def _resolve_raw_value(self, value_node: Tree) -> Any:
+        """Extract raw value from a value node."""
+        for child in value_node.children:
+            if isinstance(child, Tree) and child.data == "function":
+                return await self._resolve_function(child)
+            if isinstance(child, Token):
+                if child.type == "RELATIVE_DATE":
+                    return _parse_relative_date(str(child))
+                if child.type == "QUOTED_STRING":
+                    # Strip surrounding quotes
+                    raw = str(child)
+                    if raw.startswith('"') and raw.endswith('"'):
+                        return raw[1:-1]
+                    return raw
+                return str(child)
+        return None
+
+    async def _resolve_function(self, func_node: Tree) -> Any:
+        func_name = None
+        args = []
+        for child in func_node.children:
+            if isinstance(child, Token) and child.type == "FUNC_NAME":
+                func_name = str(child).lower()
+            elif isinstance(child, Tree) and child.data == "func_args":
+                for arg in child.children:
+                    if isinstance(arg, Tree) and arg.data == "value":
+                        args.append(await self._resolve_raw_value(arg))
+
+        if func_name not in _KNOWN_FUNCTIONS:
+            raise JQLFunctionError(func_name or "unknown")
+
+        if func_name == "currentuser":
+            return self._context.current_user_id
+        elif func_name == "now":
+            return datetime.utcnow()
+        elif func_name == "startofday":
+            return datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+        elif func_name == "endofday":
+            return datetime.utcnow().replace(hour=23, minute=59, second=59, microsecond=0)
+        elif func_name == "startofweek":
+            now = datetime.utcnow()
+            return (now - timedelta(days=now.weekday())).replace(
+                hour=0, minute=0, second=0, microsecond=0
+            )
+        elif func_name == "startofmonth":
+            now = datetime.utcnow()
+            return now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        elif func_name == "membersof":
+            return args[0] if args else None
+
+        return None
+
+    async def _resolve_value(
+        self, canonical: str, desc: FieldDescriptor, value: Any
+    ) -> Any:
+        """Resolve a raw value to the appropriate DB value (with FK lookup)."""
+        if isinstance(value, datetime):
+            return value
+
+        if desc.lookup_table and desc.lookup_field and isinstance(value, str):
+            # Check cache first
+            cache_key = (canonical, value)
+            if cache_key in self._lookup_cache:
+                return self._lookup_cache[cache_key]
+
+            if self._context.db is None:
+                return value
+
+            table = desc.lookup_table
+            lookup_col = getattr(table, desc.lookup_field)
+            id_col = getattr(table, "id")
+
+            stmt = select(id_col).where(lookup_col == value)
+            # Add project filter if available
+            if hasattr(table, "project_id") and self._context.project_id:
+                stmt = stmt.where(table.project_id == self._context.project_id)
+
+            result = await self._context.db.execute(stmt)
+            row = result.scalar_one_or_none()
+            resolved = row if row else value
+            self._lookup_cache[cache_key] = resolved
+            return resolved
+
+        return value

--- a/backend/app/jql/exceptions.py
+++ b/backend/app/jql/exceptions.py
@@ -1,0 +1,40 @@
+"""JQL error hierarchy."""
+
+
+class JQLError(Exception):
+    """Base JQL exception."""
+
+
+class JQLSyntaxError(JQLError):
+    """Invalid JQL syntax."""
+
+    def __init__(self, message: str, position: int | None = None, line: int | None = None):
+        self.message = message
+        self.position = position
+        self.line = line
+        super().__init__(message)
+
+
+class JQLFieldError(JQLError):
+    """Unknown or invalid field."""
+
+    def __init__(self, field_name: str):
+        self.field_name = field_name
+        super().__init__(f"Unknown field: {field_name}")
+
+
+class JQLValueError(JQLError):
+    """Invalid value for a field."""
+
+    def __init__(self, field_name: str, value: str):
+        self.field_name = field_name
+        self.value = value
+        super().__init__(f"Invalid value '{value}' for field '{field_name}'")
+
+
+class JQLFunctionError(JQLError):
+    """Unknown function."""
+
+    def __init__(self, function_name: str):
+        self.function_name = function_name
+        super().__init__(f"Unknown function: {function_name}")

--- a/backend/app/jql/fields.py
+++ b/backend/app/jql/fields.py
@@ -1,0 +1,89 @@
+"""JQL field descriptors — mapping JQL names to SQLAlchemy columns."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from sqlalchemy.orm import InstrumentedAttribute
+
+from app.models.db_models import Task, TaskActivity, TaskStatus, TaskType
+from app.models.user import User
+
+
+@dataclass(frozen=True)
+class FieldDescriptor:
+    """Describes how a JQL field maps to the database."""
+
+    column: Any  # InstrumentedAttribute or special marker
+    lookup_table: type | None = None
+    lookup_field: str | None = None
+    supports_history: bool = False
+    is_text_search: bool = False
+    is_json: bool = False
+
+
+# Registry: canonical JQL name → descriptor
+FIELD_REGISTRY: dict[str, FieldDescriptor] = {
+    "type": FieldDescriptor(
+        column=Task.type_id,
+        lookup_table=TaskType,
+        lookup_field="slug",
+        supports_history=True,
+    ),
+    "status": FieldDescriptor(
+        column=Task.status_id,
+        lookup_table=TaskStatus,
+        lookup_field="slug",
+        supports_history=True,
+    ),
+    "priority": FieldDescriptor(column=Task.priority, supports_history=True),
+    "severity": FieldDescriptor(column=Task.severity),
+    "assignee": FieldDescriptor(
+        column=Task.assignee_id,
+        lookup_table=User,
+        lookup_field="username",
+        supports_history=True,
+    ),
+    "reporter": FieldDescriptor(
+        column=Task.reporter_id,
+        lookup_table=User,
+        lookup_field="username",
+    ),
+    "project": FieldDescriptor(
+        column=Task.project_id,
+        lookup_table=None,
+        lookup_field=None,
+    ),
+    "created": FieldDescriptor(column=Task.created_at),
+    "updated": FieldDescriptor(column=Task.updated_at),
+    "due": FieldDescriptor(column=Task.due_date),
+    "summary": FieldDescriptor(column=Task.title),
+    "description": FieldDescriptor(column=Task.description),
+    "text": FieldDescriptor(column=None, is_text_search=True),
+    "label": FieldDescriptor(column=Task.labels, is_json=True),
+    "parent": FieldDescriptor(column=Task.parent_id),
+    "environment": FieldDescriptor(column=Task.environment),
+    "estimated": FieldDescriptor(column=Task.estimated_hours),
+    "id": FieldDescriptor(column=Task.human_id),
+}
+
+# Jira-compatible aliases → canonical name
+FIELD_ALIASES: dict[str, str] = {
+    "issuetype": "type",
+    "duedate": "due",
+    "labels": "label",
+}
+
+# All known field names (canonical + aliases)
+ALL_FIELD_NAMES: set[str] = set(FIELD_REGISTRY.keys()) | set(FIELD_ALIASES.keys())
+
+
+def resolve_field(name: str) -> tuple[str, FieldDescriptor]:
+    """Resolve a JQL field name (with alias support) to (canonical_name, descriptor)."""
+    canonical = FIELD_ALIASES.get(name.lower(), name.lower())
+    descriptor = FIELD_REGISTRY.get(canonical)
+    if descriptor is None:
+        from app.jql.exceptions import JQLFieldError
+        raise JQLFieldError(canonical)
+    return canonical, descriptor

--- a/backend/app/jql/grammar.lark
+++ b/backend/app/jql/grammar.lark
@@ -1,0 +1,80 @@
+// JQL Grammar for ErrorLens task filtering
+// Case-insensitive keywords, Jira-compatible syntax
+
+?start: query
+
+query: expr order_by?
+
+?expr: or_expr
+
+?or_expr: and_expr (OR and_expr)*
+
+?and_expr: not_expr (AND not_expr)*
+
+?not_expr: NOT not_expr -> not_clause
+         | atom
+
+?atom: "(" expr ")"
+     | condition
+
+?condition: field WAS value                -> was_condition
+          | field CHANGED                  -> changed_condition
+          | field NOT_IN "(" value_list ")" -> not_in_condition
+          | field IN "(" value_list ")"    -> in_condition
+          | field IS NOT_KW EMPTY          -> is_not_empty
+          | field IS EMPTY                 -> is_empty
+          | field CONTAINS value           -> contains_condition
+          | field NOT_CONTAINS value       -> not_contains_condition
+          | field op value                 -> comparison
+
+field: FIELD_NAME
+
+op: OP
+
+value: function
+     | RELATIVE_DATE
+     | QUOTED_STRING
+     | UNQUOTED_VALUE
+
+value_list: value ("," value)*
+
+function: FUNC_NAME "(" func_args? ")"
+
+func_args: value ("," value)*
+
+order_by: ORDER_BY order_field ("," order_field)*
+
+order_field: field (ASC | DESC)?
+
+// --- Terminals ---
+
+// Operators
+OP: "!=" | "<=" | ">=" | "=" | "<" | ">"
+CONTAINS: "~"
+NOT_CONTAINS: "!~"
+
+// Keywords (case-insensitive)
+AND: /AND/i
+OR: /OR/i
+NOT: /NOT/i
+IN: /IN/i
+NOT_IN: /NOT/i /\s+/ /IN/i
+IS: /IS/i
+NOT_KW: /NOT/i
+EMPTY: /EMPTY/i
+WAS: /WAS/i
+CHANGED: /CHANGED/i
+ORDER_BY: /ORDER/i /\s+/ /BY/i
+ASC: /ASC/i
+DESC: /DESC/i
+
+// Values
+RELATIVE_DATE: /[+-]\d+[dwhmDWHM]/
+QUOTED_STRING: "\"" /[^"]*/ "\""
+FUNC_NAME: /[a-zA-Z_][a-zA-Z0-9_]*/
+FIELD_NAME: /[a-zA-Z_][a-zA-Z0-9_.:]*/
+UNQUOTED_VALUE: /[a-zA-Z0-9_][a-zA-Z0-9_\-.]*/
+
+// Whitespace
+%import common.WS
+%ignore WS

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -27,9 +27,11 @@ from app.routers import (
     generation,
     gitlab_connections,
     integrations,
+    jql,
     launches,
     notifications,
     projects,
+    saved_filters,
     sessions,
     task_settings,
     tasks,
@@ -116,6 +118,7 @@ app.include_router(sessions.router)
 app.include_router(testcase_folders.router)  # Must be before testcases (path conflict)
 app.include_router(testcase_folders.move_router)  # /testcases/{id}/move-to-folder
 app.include_router(testcases.router)
+app.include_router(jql.router)  # EL023: JQL endpoints (before tasks for /tasks/jql-* priority)
 app.include_router(tasks.router)
 app.include_router(task_settings.router)  # EL019: Task workflow settings
 app.include_router(article_folders.router)  # Must be before articles (path conflict)
@@ -135,6 +138,7 @@ app.include_router(generation.router)  # Wave 4.0: Generation API
 app.include_router(notifications.router)  # EL018: Notifications
 app.include_router(gitlab_connections.router)  # EL020: GitLab Integration
 app.include_router(launches.router)  # EL022: Launch upload from CI
+app.include_router(saved_filters.router)  # EL023: JQL saved filters
 app.include_router(ws_router)  # Wave 4.0: WebSocket
 
 # Static files setup

--- a/backend/app/models/db_models.py
+++ b/backend/app/models/db_models.py
@@ -961,3 +961,25 @@ class EntityLink(Base):
     link_type: Mapped[str] = mapped_column(String(20))  # verifies, related
 
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+
+class SavedFilter(Base):
+    """User-saved JQL filter."""
+
+    __tablename__ = "saved_filters"
+    __table_args__ = (
+        UniqueConstraint("owner_id", "project_id", "name", name="uq_saved_filter_owner_project_name"),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=generate_uuid)
+    owner_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("users.id", ondelete="CASCADE")
+    )
+    project_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("projects.id", ondelete="CASCADE")
+    )
+    name: Mapped[str] = mapped_column(String(100))
+    jql: Mapped[str] = mapped_column(Text)
+    is_shared: Mapped[bool] = mapped_column(Boolean, default=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)

--- a/backend/app/routers/jql.py
+++ b/backend/app/routers/jql.py
@@ -1,0 +1,163 @@
+"""JQL endpoints — validate, suggest, AI translate."""
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.jql import JQLCompiler, JQLError, JQLSyntaxError
+from app.jql.fields import ALL_FIELD_NAMES, FIELD_REGISTRY
+from app.middleware.jwt_auth import require_auth
+from app.models.db_models import ProjectMember, TaskStatus, TaskType
+from app.models.user import User
+
+router = APIRouter(prefix="/tasks", tags=["jql"])
+
+
+@router.get("/jql-validate")
+async def jql_validate(
+    jql: str = Query(..., description="JQL string to validate"),
+    user: User = Depends(require_auth),
+):
+    """Validate JQL syntax without executing."""
+    compiler = JQLCompiler()
+    try:
+        compiler.parse_only(jql)
+        return {"valid": True}
+    except JQLSyntaxError as e:
+        return {"valid": False, "error": e.message, "position": e.position}
+    except JQLError as e:
+        return {"valid": False, "error": str(e)}
+
+
+@router.get("/jql-suggest")
+async def jql_suggest(
+    field: str = Query(..., description="Field name for suggestions"),
+    query: str = Query(default="", description="Search prefix"),
+    project_id: str | None = None,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(require_auth),
+):
+    """Get autocomplete suggestions for a JQL field value."""
+    if not field:
+        return [{"value": name} for name in sorted(ALL_FIELD_NAMES)]
+
+    field_lower = field.lower()
+
+    if field_lower == "priority":
+        values = ["low", "medium", "high", "critical"]
+        return [{"value": v} for v in values if query.lower() in v]
+
+    if field_lower == "severity":
+        values = ["trivial", "minor", "major", "critical"]
+        return [{"value": v} for v in values if query.lower() in v]
+
+    if field_lower == "environment":
+        values = ["production", "staging", "local", "all"]
+        return [{"value": v} for v in values if query.lower() in v]
+
+    if field_lower in ("assignee", "reporter"):
+        stmt = select(User.username, User.display_name)
+        if project_id:
+            stmt = stmt.join(ProjectMember, ProjectMember.user_id == User.id).where(
+                ProjectMember.project_id == project_id
+            )
+        if query:
+            stmt = stmt.where(User.username.ilike(f"%{query}%"))
+        stmt = stmt.limit(20)
+        result = await db.execute(stmt)
+        return [
+            {"value": row.username, "label": row.display_name or row.username}
+            for row in result.all()
+        ]
+
+    if field_lower in ("status",):
+        stmt = select(TaskStatus.slug, TaskStatus.name)
+        if project_id:
+            stmt = stmt.where(TaskStatus.project_id == project_id)
+        if query:
+            stmt = stmt.where(TaskStatus.slug.ilike(f"%{query}%"))
+        result = await db.execute(stmt)
+        return [{"value": row.slug, "label": row.name} for row in result.all()]
+
+    if field_lower in ("type", "issuetype"):
+        stmt = select(TaskType.slug, TaskType.name)
+        if project_id:
+            stmt = stmt.where(TaskType.project_id == project_id)
+        if query:
+            stmt = stmt.where(TaskType.slug.ilike(f"%{query}%"))
+        result = await db.execute(stmt)
+        return [{"value": row.slug, "label": row.name} for row in result.all()]
+
+    if field_lower in ("label", "labels"):
+        from sqlalchemy import distinct, func
+
+        from app.models.db_models import Task
+
+        stmt = select(distinct(func.jsonb_array_elements_text(Task.labels))).limit(50)
+        if project_id:
+            stmt = stmt.where(Task.project_id == project_id)
+        try:
+            result = await db.execute(stmt)
+            labels = [row[0] for row in result.all()]
+            if query:
+                labels = [l for l in labels if query.lower() in l.lower()]
+            return [{"value": l} for l in labels]
+        except Exception:
+            return []
+
+    return []
+
+
+@router.post("/jql-ai")
+async def jql_ai(
+    data: dict,
+    user: User = Depends(require_auth),
+):
+    """Convert natural language query to JQL using Claude API."""
+    import httpx
+
+    from app.config import settings
+
+    query_text = data.get("query", "")
+    if not query_text:
+        raise HTTPException(status_code=400, detail="query is required")
+
+    api_key = settings.ANTHROPIC_API_KEY
+    if not api_key:
+        raise HTTPException(status_code=503, detail="Anthropic API key not configured")
+
+    field_list = ", ".join(sorted(FIELD_REGISTRY.keys()))
+    system_prompt = (
+        "Ты конвертируешь запросы на естественном языке в JQL для системы "
+        "управления задачами ErrorLens. "
+        f"Доступные поля: {field_list}. "
+        "Операторы: =, !=, <, >, <=, >=, in, not in, ~, !~, IS EMPTY, IS NOT EMPTY, WAS, CHANGED. "
+        "Функции: currentUser(), now(), startOfDay(), endOfDay(), startOfWeek(), startOfMonth(). "
+        "Верни только JQL-строку без объяснений."
+    )
+
+    try:
+        async with httpx.AsyncClient(timeout=15) as client:
+            resp = await client.post(
+                "https://api.anthropic.com/v1/messages",
+                headers={
+                    "x-api-key": api_key,
+                    "anthropic-version": "2023-06-01",
+                    "content-type": "application/json",
+                },
+                json={
+                    "model": "claude-sonnet-4-20250514",
+                    "max_tokens": 200,
+                    "system": system_prompt,
+                    "messages": [{"role": "user", "content": query_text}],
+                },
+            )
+            resp.raise_for_status()
+            result = resp.json()
+            jql_text = result["content"][0]["text"].strip()
+            return {"jql": jql_text}
+    except httpx.HTTPStatusError as e:
+        raise HTTPException(status_code=502, detail=f"LLM API error: {e.response.status_code}")
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"LLM API error: {str(e)}")

--- a/backend/app/routers/saved_filters.py
+++ b/backend/app/routers/saved_filters.py
@@ -1,0 +1,134 @@
+"""Saved JQL filters CRUD router."""
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.middleware.jwt_auth import require_auth
+from app.models.db_models import SavedFilter
+from app.models.user import User
+
+router = APIRouter(prefix="/saved-filters", tags=["saved-filters"])
+
+
+class FilterCreate(BaseModel):
+    name: str
+    jql: str
+    project_id: str
+    is_shared: bool = False
+
+
+class FilterUpdate(BaseModel):
+    name: str | None = None
+    jql: str | None = None
+    is_shared: bool | None = None
+
+
+@router.get("")
+async def list_filters(
+    project_id: str | None = None,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(require_auth),
+):
+    """List user's filters + shared filters for the project."""
+    from sqlalchemy import or_
+
+    stmt = select(SavedFilter)
+    conditions = [SavedFilter.owner_id == user.id]
+
+    if project_id:
+        stmt = stmt.where(SavedFilter.project_id == project_id)
+        conditions.append(SavedFilter.is_shared.is_(True))
+
+    stmt = stmt.where(or_(*conditions)).order_by(SavedFilter.created_at.desc())
+    result = await db.execute(stmt)
+    filters = result.scalars().all()
+
+    return [
+        {
+            "id": f.id,
+            "name": f.name,
+            "jql": f.jql,
+            "is_shared": f.is_shared,
+            "is_own": f.owner_id == user.id,
+            "project_id": f.project_id,
+            "created_at": f.created_at.isoformat() if f.created_at else None,
+        }
+        for f in filters
+    ]
+
+
+@router.post("")
+async def create_filter(
+    data: FilterCreate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(require_auth),
+):
+    """Create a saved filter."""
+    f = SavedFilter(
+        owner_id=user.id,
+        project_id=data.project_id,
+        name=data.name,
+        jql=data.jql,
+        is_shared=data.is_shared,
+    )
+    db.add(f)
+    await db.commit()
+    await db.refresh(f)
+    return {"id": f.id, "message": "Filter saved"}
+
+
+@router.put("/{filter_id}")
+async def update_filter(
+    filter_id: str,
+    data: FilterUpdate,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(require_auth),
+):
+    """Update a saved filter (owner only)."""
+    result = await db.execute(
+        select(SavedFilter).where(SavedFilter.id == filter_id)
+    )
+    f = result.scalar_one_or_none()
+    if not f:
+        raise HTTPException(status_code=404, detail="Filter not found")
+    if f.owner_id != user.id and not user.is_admin:
+        raise HTTPException(status_code=403, detail="Not allowed")
+
+    if data.name is not None:
+        f.name = data.name
+    if data.jql is not None:
+        f.jql = data.jql
+    if data.is_shared is not None:
+        f.is_shared = data.is_shared
+    f.updated_at = datetime.utcnow()
+
+    await db.commit()
+    return {"message": "Filter updated"}
+
+
+@router.delete("/{filter_id}")
+async def delete_filter(
+    filter_id: str,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(require_auth),
+):
+    """Delete a saved filter (owner or admin)."""
+    from sqlalchemy import delete
+
+    result = await db.execute(
+        select(SavedFilter).where(SavedFilter.id == filter_id)
+    )
+    f = result.scalar_one_or_none()
+    if not f:
+        raise HTTPException(status_code=404, detail="Filter not found")
+    if f.owner_id != user.id and not user.is_admin:
+        raise HTTPException(status_code=403, detail="Not allowed")
+
+    await db.execute(delete(SavedFilter).where(SavedFilter.id == filter_id))
+    await db.commit()
+    return {"message": "Filter deleted"}

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
+from app.jql import JQLCompiler, JQLContext, JQLError, JQLSyntaxError
 from app.middleware.jwt_auth import require_auth
 from app.models.user import User
 from app.services.task_service import TaskService
@@ -69,6 +70,7 @@ class CommentUpdate(BaseModel):
 @router.get("")
 async def list_tasks(
     q: str | None = Query(default=None, description="Search query"),
+    jql: str | None = Query(default=None, description="JQL filter"),
     status: str | None = None,
     priority: str | None = None,
     assignee: str | None = None,
@@ -79,8 +81,37 @@ async def list_tasks(
     db: AsyncSession = Depends(get_db),
     user: User = Depends(require_auth),
 ):
-    """List tasks with filters."""
+    """List tasks with filters. Supports JQL queries."""
     service = TaskService(db)
+
+    if jql:
+        try:
+            compiler = JQLCompiler()
+            ctx = JQLContext(
+                current_user_id=user.id,
+                project_id=project_id,
+                db=db,
+            )
+            result = await compiler.compile(jql, ctx)
+            return await service.list_tasks_jql(
+                where_clause=result.where_clause,
+                order_clauses=result.order_clauses,
+                project_id=project_id,
+            )
+        except JQLSyntaxError as e:
+            raise HTTPException(status_code=400, detail={
+                "error": "jql_syntax_error",
+                "message": e.message,
+                "position": e.position,
+                "jql": jql,
+            })
+        except JQLError as e:
+            raise HTTPException(status_code=400, detail={
+                "error": "jql_error",
+                "message": str(e),
+                "jql": jql,
+            })
+
     if q:
         return await service.search_tasks(q, limit=20)
     return await service.list_tasks(

--- a/backend/app/services/task_service.py
+++ b/backend/app/services/task_service.py
@@ -156,6 +156,40 @@ class TaskService:
         )
         return [self._to_list_dict(t) for t in tasks]
 
+    async def list_tasks_jql(
+        self,
+        where_clause: Any,
+        order_clauses: list[Any] | None = None,
+        project_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """List tasks using a compiled JQL WHERE clause."""
+        from sqlalchemy import select
+        from sqlalchemy.orm import joinedload
+
+        stmt = select(Task).options(
+            joinedload(Task.task_type),
+            joinedload(Task.task_status),
+            joinedload(Task.assignee_user),
+            joinedload(Task.reporter),
+        )
+
+        if project_id:
+            stmt = stmt.where(Task.project_id == project_id)
+
+        if where_clause is not None:
+            stmt = stmt.where(where_clause)
+
+        if order_clauses:
+            for clause in order_clauses:
+                stmt = stmt.order_by(clause)
+        else:
+            stmt = stmt.order_by(Task.created_at.desc())
+
+        stmt = stmt.limit(200)
+        result = await self.db.execute(stmt)
+        tasks = result.unique().scalars().all()
+        return [self._to_list_dict(t) for t in tasks]
+
     async def search_tasks(
         self,
         q: str,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -44,6 +44,9 @@ bcrypt>=4.0.0
 # Encryption
 cryptography>=42.0.0
 
+# JQL parser
+lark>=1.1.0
+
 # Linting (dev)
 ruff>=0.1.0
 black>=24.0.0

--- a/backend/tests/jql/test_compiler.py
+++ b/backend/tests/jql/test_compiler.py
@@ -1,0 +1,188 @@
+"""Tests for JQL compiler (AST → SQLAlchemy)."""
+
+import pytest
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+
+from app.jql.compiler import JQLCompiler, JQLContext, _parse_relative_date
+from app.jql.exceptions import JQLFieldError, JQLFunctionError, JQLSyntaxError
+
+
+@pytest.fixture
+def compiler():
+    return JQLCompiler()
+
+
+@pytest.fixture
+def context():
+    return JQLContext(
+        current_user_id="user-123",
+        project_id="proj-456",
+        db=None,
+    )
+
+
+class TestRelativeDateParsing:
+
+    def test_minus_7_days(self):
+        result = _parse_relative_date("-7d")
+        expected = datetime.utcnow() - timedelta(days=7)
+        assert abs((result - expected).total_seconds()) < 2
+
+    def test_plus_1_hour(self):
+        result = _parse_relative_date("+1h")
+        expected = datetime.utcnow() + timedelta(hours=1)
+        assert abs((result - expected).total_seconds()) < 2
+
+    def test_minus_2_weeks(self):
+        result = _parse_relative_date("-2w")
+        expected = datetime.utcnow() - timedelta(weeks=2)
+        assert abs((result - expected).total_seconds()) < 2
+
+    def test_minus_30_minutes(self):
+        result = _parse_relative_date("-30m")
+        expected = datetime.utcnow() - timedelta(minutes=30)
+        assert abs((result - expected).total_seconds()) < 2
+
+
+class TestCompiler:
+
+    @pytest.mark.asyncio
+    async def test_compile_equality(self, compiler, context):
+        result = await compiler.compile('priority = high', context)
+        assert result.where_clause is not None
+
+    @pytest.mark.asyncio
+    async def test_compile_in(self, compiler, context):
+        result = await compiler.compile('priority in (High, Critical)', context)
+        assert result.where_clause is not None
+
+    @pytest.mark.asyncio
+    async def test_compile_current_user(self, compiler, context):
+        result = await compiler.compile('assignee = currentUser()', context)
+        assert result.where_clause is not None
+        # The compiled clause should use context.current_user_id
+        clause_str = str(result.where_clause.compile(compile_kwargs={"literal_binds": True}))
+        assert "user-123" in clause_str
+
+    @pytest.mark.asyncio
+    async def test_compile_relative_date(self, compiler, context):
+        result = await compiler.compile('created >= -7d', context)
+        assert result.where_clause is not None
+
+    @pytest.mark.asyncio
+    async def test_compile_text_search(self, compiler, context):
+        result = await compiler.compile('text ~ "login"', context)
+        assert result.where_clause is not None
+        clause_str = str(result.where_clause)
+        # Should search both title and description
+        assert "title" in clause_str.lower() or "ILIKE" in clause_str
+
+    @pytest.mark.asyncio
+    async def test_compile_was(self, compiler, context):
+        result = await compiler.compile('status WAS todo', context)
+        assert result.where_clause is not None
+
+    @pytest.mark.asyncio
+    async def test_compile_changed(self, compiler, context):
+        result = await compiler.compile('status CHANGED', context)
+        assert result.where_clause is not None
+
+    @pytest.mark.asyncio
+    async def test_unknown_field(self, compiler, context):
+        with pytest.raises(JQLFieldError):
+            await compiler.compile('unknownfield = test', context)
+
+    @pytest.mark.asyncio
+    async def test_compile_is_empty(self, compiler, context):
+        result = await compiler.compile('severity IS EMPTY', context)
+        assert result.where_clause is not None
+
+    @pytest.mark.asyncio
+    async def test_compile_is_not_empty(self, compiler, context):
+        result = await compiler.compile('severity IS NOT EMPTY', context)
+        assert result.where_clause is not None
+
+    @pytest.mark.asyncio
+    async def test_compile_not_in(self, compiler, context):
+        result = await compiler.compile('priority NOT IN (Low, Trivial)', context)
+        assert result.where_clause is not None
+
+    @pytest.mark.asyncio
+    async def test_compile_and(self, compiler, context):
+        result = await compiler.compile('priority = high AND severity = critical', context)
+        assert result.where_clause is not None
+
+    @pytest.mark.asyncio
+    async def test_compile_or(self, compiler, context):
+        result = await compiler.compile('priority = high OR priority = critical', context)
+        assert result.where_clause is not None
+
+    @pytest.mark.asyncio
+    async def test_compile_not(self, compiler, context):
+        result = await compiler.compile('NOT priority = low', context)
+        assert result.where_clause is not None
+
+    @pytest.mark.asyncio
+    async def test_compile_order_by(self, compiler, context):
+        result = await compiler.compile('priority = high ORDER BY created DESC', context)
+        assert result.where_clause is not None
+        assert len(result.order_clauses) == 1
+
+    @pytest.mark.asyncio
+    async def test_compile_order_by_multiple(self, compiler, context):
+        result = await compiler.compile('priority = high ORDER BY priority ASC, created DESC', context)
+        assert len(result.order_clauses) == 2
+
+    @pytest.mark.asyncio
+    async def test_compile_not_contains(self, compiler, context):
+        result = await compiler.compile('summary !~ "test"', context)
+        assert result.where_clause is not None
+
+    @pytest.mark.asyncio
+    async def test_fk_lookup_cached(self, compiler, context):
+        """One SELECT to users for two mentions of same field."""
+        mock_db = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = "resolved-id"
+        mock_db.execute.return_value = mock_result
+
+        context.db = mock_db
+        result = await compiler.compile(
+            'assignee = "ivan" OR assignee = "ivan"', context
+        )
+        # Should only call execute once due to caching
+        assert mock_db.execute.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_unknown_function(self, compiler, context):
+        with pytest.raises(JQLFunctionError):
+            await compiler.compile('assignee = unknownFunc()', context)
+
+    @pytest.mark.asyncio
+    async def test_none_handling(self, compiler, context):
+        """Null/empty queries should raise syntax error."""
+        with pytest.raises(JQLSyntaxError):
+            await compiler.compile('', context)
+
+    @pytest.mark.asyncio
+    async def test_compile_parentheses(self, compiler, context):
+        result = await compiler.compile(
+            'type = Bug AND (priority = high OR severity = critical)', context
+        )
+        assert result.where_clause is not None
+
+    @pytest.mark.asyncio
+    async def test_compile_jira_alias(self, compiler, context):
+        """issuetype should resolve to type field."""
+        result = await compiler.compile('issuetype = Bug', context)
+        assert result.where_clause is not None
+
+    @pytest.mark.asyncio
+    async def test_compile_startofday(self, compiler, context):
+        result = await compiler.compile('created >= startOfDay()', context)
+        assert result.where_clause is not None

--- a/backend/tests/jql/test_parser.py
+++ b/backend/tests/jql/test_parser.py
@@ -1,0 +1,139 @@
+"""Tests for JQL grammar parser."""
+
+import pytest
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+
+from app.jql.compiler import _get_parser, JQLCompiler
+from app.jql.exceptions import JQLSyntaxError
+
+
+@pytest.fixture
+def parser():
+    return _get_parser()
+
+
+@pytest.fixture
+def compiler():
+    return JQLCompiler()
+
+
+class TestParser:
+    """Test JQL grammar parsing."""
+
+    def test_simple_equality(self, parser):
+        tree = parser.parse('status = "todo"')
+        assert tree is not None
+
+    def test_unquoted_value(self, parser):
+        tree = parser.parse('status = todo')
+        assert tree is not None
+
+    def test_in_operator(self, parser):
+        tree = parser.parse('priority in (High, Critical)')
+        assert tree is not None
+
+    def test_and_or(self, parser):
+        tree = parser.parse('status = todo AND priority = high OR severity = critical')
+        assert tree is not None
+
+    def test_not_operator(self, parser):
+        tree = parser.parse('NOT status = Done')
+        assert tree is not None
+
+    def test_current_user(self, parser):
+        tree = parser.parse('assignee = currentUser()')
+        assert tree is not None
+
+    def test_relative_date(self, parser):
+        tree = parser.parse('created >= -7d')
+        assert tree is not None
+
+    def test_order_by(self, parser):
+        tree = parser.parse('status = todo ORDER BY created DESC')
+        assert tree is not None
+
+    def test_order_by_multiple(self, parser):
+        tree = parser.parse('status = todo ORDER BY priority ASC, created DESC')
+        assert tree is not None
+
+    def test_was_operator(self, parser):
+        tree = parser.parse('status WAS "Done"')
+        assert tree is not None
+
+    def test_changed_operator(self, parser):
+        tree = parser.parse('status CHANGED')
+        assert tree is not None
+
+    def test_syntax_error(self, compiler):
+        with pytest.raises(JQLSyntaxError):
+            compiler.parse_only('= = =')
+
+    def test_case_insensitive(self, parser):
+        """AND, and, And should all work."""
+        tree1 = parser.parse('status = todo AND priority = high')
+        tree2 = parser.parse('status = todo and priority = high')
+        tree3 = parser.parse('status = todo And priority = high')
+        assert tree1 is not None
+        assert tree2 is not None
+        assert tree3 is not None
+
+    def test_jira_aliases(self, parser):
+        tree = parser.parse('issuetype = Bug')
+        assert tree is not None
+
+    def test_duedate_alias(self, parser):
+        tree = parser.parse('duedate >= -2w')
+        assert tree is not None
+
+    def test_is_empty(self, parser):
+        tree = parser.parse('summary IS EMPTY')
+        assert tree is not None
+
+    def test_is_not_empty(self, parser):
+        tree = parser.parse('summary IS NOT EMPTY')
+        assert tree is not None
+
+    def test_not_in(self, parser):
+        tree = parser.parse('priority NOT IN (Low, Trivial)')
+        assert tree is not None
+
+    def test_contains(self, parser):
+        tree = parser.parse('text ~ "login"')
+        assert tree is not None
+
+    def test_not_contains(self, parser):
+        tree = parser.parse('summary !~ "test"')
+        assert tree is not None
+
+    def test_parentheses(self, parser):
+        tree = parser.parse('type = Bug AND (priority = High OR priority = Critical)')
+        assert tree is not None
+
+    def test_complex_query(self, parser):
+        jql = 'assignee = currentUser() AND status != Done AND priority in (High, Critical) ORDER BY created DESC'
+        tree = parser.parse(jql)
+        assert tree is not None
+
+    def test_empty_input(self, compiler):
+        """Empty input should raise syntax error."""
+        with pytest.raises(JQLSyntaxError):
+            compiler.parse_only('')
+
+    def test_function_startOfDay(self, parser):
+        tree = parser.parse('created >= startOfDay()')
+        assert tree is not None
+
+    def test_relative_date_weeks(self, parser):
+        tree = parser.parse('created >= -2w')
+        assert tree is not None
+
+    def test_relative_date_hours(self, parser):
+        tree = parser.parse('updated >= -4h')
+        assert tree is not None
+
+    def test_relative_date_future(self, parser):
+        tree = parser.parse('due <= +7d')
+        assert tree is not None

--- a/dashboard-vue/src/components/tasks/JQLBar.vue
+++ b/dashboard-vue/src/components/tasks/JQLBar.vue
@@ -1,0 +1,416 @@
+<template>
+  <div class="jql-bar">
+    <div class="jql-input-wrapper">
+      <svg class="jql-icon" viewBox="0 0 20 20" fill="currentColor" width="16" height="16">
+        <path fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clip-rule="evenodd" />
+      </svg>
+
+      <input
+        ref="inputRef"
+        v-model="jqlInput"
+        class="jql-input"
+        :class="{ invalid: !isValid && jqlInput.trim() }"
+        placeholder="JQL: status = todo AND priority = high"
+        @input="onInput"
+        @keydown.enter="onSearch"
+        @keydown.escape="onClear"
+        @focus="showSuggestions = true"
+        @blur="hideSuggestions"
+      />
+
+      <div class="jql-status" :class="statusClass" :title="statusTitle">
+        <span class="status-dot"></span>
+      </div>
+
+      <button v-if="jqlInput" class="jql-btn-clear" title="Clear" @click="onClear">
+        &times;
+      </button>
+
+      <button class="jql-btn-ai" title="Smart Search (AI)" @click="onAI">
+        ✨
+      </button>
+
+      <button class="jql-btn-search" :disabled="!isValid || !jqlInput.trim()" @click="onSearch">
+        Search
+      </button>
+
+      <button class="jql-btn-save" title="Save Filter" @click="onSave" :disabled="!jqlInput.trim()">
+        <svg viewBox="0 0 20 20" fill="currentColor" width="14" height="14">
+          <path d="M5 4a2 2 0 012-2h6a2 2 0 012 2v14l-5-2.5L5 18V4z" />
+        </svg>
+      </button>
+    </div>
+
+    <!-- Autocomplete dropdown -->
+    <div v-if="showSuggestions && suggestions.length" class="jql-autocomplete">
+      <div
+        v-for="(s, i) in suggestions"
+        :key="s.value"
+        class="suggestion-item"
+        :class="{ active: i === activeSuggestion }"
+        @mousedown.prevent="applySuggestion(s)"
+      >
+        <span class="suggestion-value">{{ s.value }}</span>
+        <span v-if="s.label && s.label !== s.value" class="suggestion-label">{{ s.label }}</span>
+      </div>
+    </div>
+
+    <!-- Error message -->
+    <div v-if="syntaxError && jqlInput.trim()" class="jql-error">
+      {{ syntaxError.message }}
+    </div>
+
+    <!-- Save filter modal -->
+    <div v-if="showSaveModal" class="save-modal-overlay" @click.self="showSaveModal = false">
+      <div class="save-modal">
+        <h3>Save Filter</h3>
+        <input v-model="filterName" placeholder="Filter name" @keydown.enter="confirmSave" />
+        <label class="shared-check">
+          <input type="checkbox" v-model="filterShared" /> Share with project
+        </label>
+        <div class="save-actions">
+          <button class="btn btn-secondary" @click="showSaveModal = false">Cancel</button>
+          <button class="btn btn-primary" @click="confirmSave" :disabled="!filterName.trim()">Save</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue'
+import { useJqlStore } from '@/stores/jql'
+
+const props = defineProps({
+  projectId: { type: String, default: null },
+})
+
+const emit = defineEmits(['search', 'clear'])
+
+const jqlStore = useJqlStore()
+
+const inputRef = ref(null)
+const jqlInput = ref('')
+const showSuggestions = ref(false)
+const activeSuggestion = ref(-1)
+const showSaveModal = ref(false)
+const filterName = ref('')
+const filterShared = ref(false)
+
+let debounceTimer = null
+
+const isValid = computed(() => jqlStore.isValid)
+const syntaxError = computed(() => jqlStore.syntaxError)
+const suggestions = computed(() => jqlStore.suggestions)
+
+const statusClass = computed(() => {
+  if (!jqlInput.value.trim()) return 'neutral'
+  return isValid.value ? 'valid' : 'invalid'
+})
+
+const statusTitle = computed(() => {
+  if (!jqlInput.value.trim()) return 'Enter JQL query'
+  return isValid.value ? 'Valid JQL' : syntaxError.value?.message || 'Invalid JQL'
+})
+
+function onInput() {
+  clearTimeout(debounceTimer)
+  debounceTimer = setTimeout(() => {
+    jqlStore.validateJQL(jqlInput.value)
+    analyzeContext()
+  }, 300)
+}
+
+function analyzeContext() {
+  const text = jqlInput.value
+  const cursor = inputRef.value?.selectionStart || text.length
+
+  const before = text.substring(0, cursor).trim()
+  const tokens = before.split(/\s+/)
+
+  if (tokens.length >= 2) {
+    const lastToken = tokens[tokens.length - 1]
+    const operators = ['=', '!=', '>', '<', '>=', '<=', '~', '!~', 'in', 'not']
+    if (operators.includes(lastToken.toLowerCase())) {
+      // After operator — suggest values for the field
+      const fieldToken = tokens[tokens.length - 2]
+      jqlStore.fetchSuggestions(fieldToken, '', props.projectId)
+      return
+    }
+  }
+
+  // After AND/OR or at start — suggest field names
+  const lastToken = tokens[tokens.length - 1]?.toLowerCase()
+  if (!lastToken || lastToken === 'and' || lastToken === 'or' || lastToken === 'not') {
+    jqlStore.fetchSuggestions('', '', props.projectId)
+  } else {
+    jqlStore.suggestions = []
+  }
+}
+
+function applySuggestion(s) {
+  const text = jqlInput.value
+  const cursor = inputRef.value?.selectionStart || text.length
+  const before = text.substring(0, cursor).trimEnd()
+  const after = text.substring(cursor)
+
+  // Replace the current incomplete token
+  const tokens = before.split(/\s+/)
+  const lastToken = tokens[tokens.length - 1]
+  const operators = ['=', '!=', '>', '<', '>=', '<=', '~', '!~', 'in', 'not']
+
+  let value = s.value
+  if (value.includes(' ')) value = `"${value}"`
+
+  if (operators.includes(lastToken?.toLowerCase())) {
+    jqlInput.value = before + ' ' + value + after
+  } else {
+    jqlInput.value = tokens.slice(0, -1).join(' ') + (tokens.length > 1 ? ' ' : '') + value + after
+  }
+
+  showSuggestions.value = false
+  jqlStore.suggestions = []
+}
+
+function hideSuggestions() {
+  setTimeout(() => { showSuggestions.value = false }, 200)
+}
+
+function onSearch() {
+  if (!jqlInput.value.trim() || !isValid.value) return
+  jqlStore.executeJQL(jqlInput.value, props.projectId)
+  emit('search', jqlInput.value)
+  showSuggestions.value = false
+}
+
+function onClear() {
+  jqlInput.value = ''
+  jqlStore.clearJQL()
+  emit('clear')
+}
+
+async function onAI() {
+  const text = jqlInput.value.trim()
+  if (!text) return
+  const result = await jqlStore.askAI(text, props.projectId)
+  if (result) {
+    jqlInput.value = result
+    jqlStore.validateJQL(result)
+  }
+}
+
+function onSave() {
+  if (!jqlInput.value.trim()) return
+  filterName.value = ''
+  filterShared.value = false
+  showSaveModal.value = true
+}
+
+async function confirmSave() {
+  if (!filterName.value.trim()) return
+  await jqlStore.saveFilter(filterName.value, jqlInput.value, props.projectId, filterShared.value)
+  showSaveModal.value = false
+}
+
+// Apply external JQL (from saved filters)
+function setJQL(jql) {
+  jqlInput.value = jql
+  jqlStore.validateJQL(jql)
+  onSearch()
+}
+
+defineExpose({ setJQL })
+</script>
+
+<style scoped>
+.jql-bar {
+  position: relative;
+  margin-bottom: 16px;
+}
+
+.jql-input-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--bg-card);
+  border: 1px solid var(--bg-secondary);
+  border-radius: 8px;
+  padding: 6px 12px;
+  transition: border-color 0.2s;
+}
+
+.jql-input-wrapper:focus-within {
+  border-color: var(--accent);
+}
+
+.jql-icon {
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.jql-input {
+  flex: 1;
+  border: none;
+  background: none;
+  outline: none;
+  color: var(--text-primary);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 13px;
+  padding: 4px 0;
+}
+
+.jql-input::placeholder {
+  color: var(--text-secondary);
+  opacity: 0.6;
+}
+
+.jql-input.invalid {
+  color: #ef4444;
+}
+
+.jql-status {
+  flex-shrink: 0;
+}
+
+.status-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.jql-status.neutral .status-dot { background: var(--text-secondary); opacity: 0.3; }
+.jql-status.valid .status-dot { background: #10b981; }
+.jql-status.invalid .status-dot { background: #ef4444; }
+
+.jql-btn-clear {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 18px;
+  cursor: pointer;
+  padding: 0 4px;
+  line-height: 1;
+}
+
+.jql-btn-ai {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  padding: 2px 4px;
+  border-radius: 4px;
+  transition: background 0.2s;
+}
+
+.jql-btn-ai:hover { background: var(--bg-secondary); }
+
+.jql-btn-search {
+  background: var(--accent);
+  color: white;
+  border: none;
+  padding: 4px 12px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.jql-btn-search:disabled { opacity: 0.5; cursor: not-allowed; }
+.jql-btn-search:not(:disabled):hover { opacity: 0.9; }
+
+.jql-btn-save {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 4px;
+  transition: background 0.2s;
+  display: flex;
+  align-items: center;
+}
+
+.jql-btn-save:hover { background: var(--bg-secondary); }
+.jql-btn-save:disabled { opacity: 0.3; cursor: not-allowed; }
+
+.jql-autocomplete {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: var(--bg-card);
+  border: 1px solid var(--bg-secondary);
+  border-radius: 8px;
+  margin-top: 4px;
+  max-height: 200px;
+  overflow-y: auto;
+  z-index: 100;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+}
+
+.suggestion-item {
+  padding: 8px 12px;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  font-size: 13px;
+  transition: background 0.1s;
+}
+
+.suggestion-item:hover,
+.suggestion-item.active {
+  background: var(--bg-secondary);
+}
+
+.suggestion-value { font-family: monospace; }
+.suggestion-label { color: var(--text-secondary); font-size: 12px; }
+
+.jql-error {
+  color: #ef4444;
+  font-size: 12px;
+  margin-top: 4px;
+  padding-left: 36px;
+}
+
+.save-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1100;
+}
+
+.save-modal {
+  background: var(--bg-card);
+  border-radius: 12px;
+  padding: 20px;
+  width: 360px;
+}
+
+.save-modal h3 { margin: 0 0 12px; font-size: 16px; }
+
+.save-modal input[type="text"],
+.save-modal input:not([type]) {
+  width: 100%;
+  margin-bottom: 12px;
+}
+
+.shared-check {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin-bottom: 16px;
+}
+
+.save-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+</style>

--- a/dashboard-vue/src/components/tasks/SavedFilters.vue
+++ b/dashboard-vue/src/components/tasks/SavedFilters.vue
@@ -1,0 +1,143 @@
+<template>
+  <div v-if="filters.length" class="saved-filters">
+    <div class="filters-header">
+      <span class="filters-title">Saved Filters</span>
+    </div>
+
+    <div v-if="myFilters.length" class="filter-group">
+      <span class="group-label">My Filters</span>
+      <div
+        v-for="f in myFilters"
+        :key="f.id"
+        class="filter-item"
+        :class="{ active: f.jql === activeJQL }"
+        @click="$emit('apply', f.jql)"
+      >
+        <span class="filter-name">{{ f.name }}</span>
+        <div class="filter-actions">
+          <button
+            class="filter-action-btn"
+            :title="f.is_shared ? 'Shared' : 'Private'"
+            @click.stop="toggleShare(f)"
+          >
+            {{ f.is_shared ? '🌐' : '🔒' }}
+          </button>
+          <button class="filter-action-btn delete" title="Delete" @click.stop="onDelete(f)">
+            &times;
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="sharedFilters.length" class="filter-group">
+      <span class="group-label">Shared</span>
+      <div
+        v-for="f in sharedFilters"
+        :key="f.id"
+        class="filter-item"
+        :class="{ active: f.jql === activeJQL }"
+        @click="$emit('apply', f.jql)"
+      >
+        <span class="filter-name">{{ f.name }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { useJqlStore } from '@/stores/jql'
+
+const props = defineProps({
+  projectId: { type: String, default: null },
+  activeJQL: { type: String, default: '' },
+})
+
+defineEmits(['apply'])
+
+const jqlStore = useJqlStore()
+
+const filters = computed(() => jqlStore.savedFilters)
+const myFilters = computed(() => filters.value.filter(f => f.is_own))
+const sharedFilters = computed(() => filters.value.filter(f => !f.is_own && f.is_shared))
+
+async function toggleShare(f) {
+  const { savedFiltersApi } = await import('@/services/api')
+  await savedFiltersApi.update(f.id, { is_shared: !f.is_shared })
+  await jqlStore.fetchSavedFilters(props.projectId)
+}
+
+async function onDelete(f) {
+  await jqlStore.deleteFilter(f.id, props.projectId)
+}
+</script>
+
+<style scoped>
+.saved-filters {
+  margin-bottom: 12px;
+}
+
+.filters-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.filters-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.filter-group {
+  margin-bottom: 8px;
+}
+
+.group-label {
+  font-size: 11px;
+  color: var(--text-secondary);
+  opacity: 0.7;
+  display: block;
+  margin-bottom: 4px;
+}
+
+.filter-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+  transition: background 0.15s;
+}
+
+.filter-item:hover { background: var(--bg-secondary); }
+.filter-item.active { background: var(--accent); color: white; }
+
+.filter-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+.filter-actions {
+  display: flex;
+  gap: 2px;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.filter-item:hover .filter-actions { opacity: 1; }
+
+.filter-action-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 12px;
+  padding: 2px 4px;
+  border-radius: 4px;
+  color: var(--text-secondary);
+}
+
+.filter-action-btn:hover { background: rgba(255,255,255,0.1); }
+.filter-action-btn.delete:hover { color: #ef4444; }
+</style>

--- a/dashboard-vue/src/services/api.js
+++ b/dashboard-vue/src/services/api.js
@@ -118,6 +118,18 @@ export const tasksApi = {
   getRelations: (id) => api.get(`/tasks/${id}/relations`),
   createRelation: (id, data) => api.post(`/tasks/${id}/relations`, data),
   deleteRelation: (taskId, relationId) => api.delete(`/tasks/${taskId}/relations/${relationId}`),
+  // JQL
+  jqlValidate: (jql) => api.get('/tasks/jql-validate', { params: { jql } }),
+  jqlSuggest: (field, query, projectId) => api.get('/tasks/jql-suggest', { params: { field, query, project_id: projectId } }),
+  jqlAi: (query, projectId) => api.post('/tasks/jql-ai', { query, project_id: projectId }),
+}
+
+// Saved Filters API
+export const savedFiltersApi = {
+  list: (projectId) => api.get('/saved-filters', { params: { project_id: projectId } }),
+  create: (data) => api.post('/saved-filters', data),
+  update: (id, data) => api.put(`/saved-filters/${id}`, data),
+  remove: (id) => api.delete(`/saved-filters/${id}`),
 }
 
 // Task Settings API

--- a/dashboard-vue/src/stores/jql.js
+++ b/dashboard-vue/src/stores/jql.js
@@ -1,0 +1,107 @@
+import { defineStore } from 'pinia'
+import { tasksApi, savedFiltersApi } from '@/services/api'
+
+export const useJqlStore = defineStore('jql', {
+  state: () => ({
+    currentJQL: '',
+    isValid: true,
+    syntaxError: null,
+    savedFilters: [],
+    suggestions: [],
+    jqlResults: [],
+    loading: false,
+  }),
+
+  actions: {
+    async validateJQL(jql) {
+      if (!jql.trim()) {
+        this.isValid = true
+        this.syntaxError = null
+        return
+      }
+      try {
+        const res = await tasksApi.jqlValidate(jql)
+        this.isValid = res.data.valid
+        this.syntaxError = res.data.valid ? null : { message: res.data.error, position: res.data.position }
+      } catch {
+        this.isValid = false
+      }
+    },
+
+    async executeJQL(jql, projectId) {
+      if (!jql.trim()) {
+        this.jqlResults = []
+        return
+      }
+      this.loading = true
+      try {
+        const res = await tasksApi.list({ jql, project_id: projectId })
+        this.jqlResults = res.data
+        this.currentJQL = jql
+      } catch (e) {
+        const detail = e.response?.data?.detail
+        if (detail?.error === 'jql_syntax_error') {
+          this.syntaxError = { message: detail.message, position: detail.position }
+          this.isValid = false
+        }
+        this.jqlResults = []
+      } finally {
+        this.loading = false
+      }
+    },
+
+    async fetchSuggestions(field, query, projectId) {
+      try {
+        const res = await tasksApi.jqlSuggest(field, query, projectId)
+        this.suggestions = res.data
+      } catch {
+        this.suggestions = []
+      }
+    },
+
+    async askAI(text, projectId) {
+      try {
+        const res = await tasksApi.jqlAi(text, projectId)
+        return res.data.jql
+      } catch {
+        return null
+      }
+    },
+
+    async fetchSavedFilters(projectId) {
+      try {
+        const res = await savedFiltersApi.list(projectId)
+        this.savedFilters = res.data
+      } catch {
+        this.savedFilters = []
+      }
+    },
+
+    async saveFilter(name, jql, projectId, isShared = false) {
+      try {
+        await savedFiltersApi.create({ name, jql, project_id: projectId, is_shared: isShared })
+        await this.fetchSavedFilters(projectId)
+        return true
+      } catch {
+        return false
+      }
+    },
+
+    async deleteFilter(id, projectId) {
+      try {
+        await savedFiltersApi.remove(id)
+        await this.fetchSavedFilters(projectId)
+        return true
+      } catch {
+        return false
+      }
+    },
+
+    clearJQL() {
+      this.currentJQL = ''
+      this.isValid = true
+      this.syntaxError = null
+      this.jqlResults = []
+    },
+  },
+})

--- a/dashboard-vue/src/views/TasksView.vue
+++ b/dashboard-vue/src/views/TasksView.vue
@@ -7,33 +7,107 @@
       </button>
     </div>
 
-    <!-- Type filter tabs -->
-    <div class="type-tabs">
-      <button
-        class="type-tab"
-        :class="{ active: activeTypeFilter === 'all' }"
-        @click="filterByType('all')"
-      >
-        All
-      </button>
-      <button
-        v-for="t in taskTypes"
-        :key="t.slug"
-        class="type-tab"
-        :class="{ active: activeTypeFilter === t.slug }"
-        :style="activeTypeFilter === t.slug ? { borderBottomColor: t.color } : {}"
-        @click="filterByType(t.slug)"
-      >
-        <AppIcon :name="t.icon" :size="14" />
-        {{ t.name }}
-      </button>
+    <!-- JQL Bar -->
+    <JQLBar
+      ref="jqlBarRef"
+      :project-id="currentProjectId"
+      @search="onJQLSearch"
+      @clear="onJQLClear"
+    />
+
+    <!-- Saved Filters -->
+    <SavedFilters
+      :project-id="currentProjectId"
+      :active-j-q-l="jqlStore.currentJQL"
+      @apply="onApplyFilter"
+    />
+
+    <!-- View Toggle + Type filter tabs -->
+    <div class="toolbar-row">
+      <div class="type-tabs">
+        <button
+          class="type-tab"
+          :class="{ active: activeTypeFilter === 'all' }"
+          @click="filterByType('all')"
+        >
+          All
+        </button>
+        <button
+          v-for="t in taskTypes"
+          :key="t.slug"
+          class="type-tab"
+          :class="{ active: activeTypeFilter === t.slug }"
+          :style="activeTypeFilter === t.slug ? { borderBottomColor: t.color } : {}"
+          @click="filterByType(t.slug)"
+        >
+          <AppIcon :name="t.icon" :size="14" />
+          {{ t.name }}
+        </button>
+      </div>
+
+      <div class="view-toggle">
+        <button
+          class="toggle-btn"
+          :class="{ active: viewMode === 'board' }"
+          @click="viewMode = 'board'"
+          title="Kanban Board"
+        >
+          <svg viewBox="0 0 20 20" fill="currentColor" width="16" height="16">
+            <path d="M3 4a1 1 0 011-1h12a1 1 0 011 1v2a1 1 0 01-1 1H4a1 1 0 01-1-1V4zM3 10a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H4a1 1 0 01-1-1v-6zM14 9a1 1 0 00-1 1v6a1 1 0 001 1h2a1 1 0 001-1v-6a1 1 0 00-1-1h-2z" />
+          </svg>
+        </button>
+        <button
+          class="toggle-btn"
+          :class="{ active: viewMode === 'list' }"
+          @click="viewMode = 'list'"
+          title="List View"
+        >
+          <svg viewBox="0 0 20 20" fill="currentColor" width="16" height="16">
+            <path fill-rule="evenodd" d="M3 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd" />
+          </svg>
+        </button>
+      </div>
     </div>
 
-    <!-- Kanban Board -->
+    <!-- Loading -->
     <div v-if="loading" class="loading">
       <div class="spinner"></div>
     </div>
 
+    <!-- JQL List View -->
+    <div v-else-if="viewMode === 'list'" class="task-list" data-testid="task-list">
+      <div v-if="!listTasks.length" class="empty-list">
+        <p v-if="jqlStore.currentJQL">No tasks match your query</p>
+        <p v-else>Enter a JQL query or switch to Board view</p>
+      </div>
+      <div
+        v-for="task in listTasks"
+        :key="task.id"
+        class="task-list-row"
+        @click="openTask(task)"
+      >
+        <div class="row-left">
+          <span v-if="task.type" class="type-indicator" :style="{ background: task.type.color }">
+            <AppIcon :name="task.type.icon" :size="10" />
+          </span>
+          <span v-if="task.human_id" class="human-id-badge">{{ task.human_id }}</span>
+          <span class="task-title">{{ task.title }}</span>
+        </div>
+        <div class="row-right">
+          <span v-if="task.task_status" class="status-pill" :style="{ background: task.task_status.color }">
+            {{ task.task_status.name }}
+          </span>
+          <span v-else class="status-pill legacy">{{ task.status }}</span>
+          <span v-if="task.severity" class="severity-badge" :class="task.severity">{{ task.severity }}</span>
+          <span class="priority-dot" :class="task.priority"></span>
+          <span v-if="task.assignee_user" class="assignee-pill">
+            {{ task.assignee_user.display_name || task.assignee_user.username }}
+          </span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Kanban Board -->
     <div v-else class="kanban-board" data-testid="kanban-board">
       <div
         v-for="column in columns"
@@ -186,13 +260,17 @@
 import { ref, computed, watch, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { useTasksStore } from '@/stores/tasks'
+import { useJqlStore } from '@/stores/jql'
 import { tasksApi, taskSettingsApi, projectsApi } from '@/services/api'
 import RichEditor from '@/components/common/RichEditor.vue'
 import AppIcon from '@/components/common/AppIcon.vue'
 import TaskDetailView from '@/components/tasks/TaskDetailView.vue'
+import JQLBar from '@/components/tasks/JQLBar.vue'
+import SavedFilters from '@/components/tasks/SavedFilters.vue'
 
 const route = useRoute()
 const store = useTasksStore()
+const jqlStore = useJqlStore()
 
 const columns = [
   { id: 'todo', title: 'To Do' },
@@ -205,7 +283,12 @@ const showCreateModal = ref(false)
 const selectedTask = ref(null)
 const taskTypes = ref([])
 const activeTypeFilter = ref('all')
+const viewMode = ref('board')
+const currentProjectId = ref(null)
+const jqlBarRef = ref(null)
 let draggedTask = null
+
+const listTasks = computed(() => jqlStore.jqlResults)
 
 const form = ref({
   title: '',
@@ -296,6 +379,20 @@ async function saveTask() {
   resetForm()
 }
 
+function onJQLSearch(jql) {
+  viewMode.value = 'list'
+}
+
+function onJQLClear() {
+  viewMode.value = 'board'
+}
+
+function onApplyFilter(jql) {
+  if (jqlBarRef.value) {
+    jqlBarRef.value.setJQL(jql)
+  }
+}
+
 async function filterByType(slug) {
   activeTypeFilter.value = slug
   const params = slug !== 'all' ? { type_slug: slug } : {}
@@ -316,8 +413,10 @@ async function loadTaskTypes() {
     const projectsRes = await projectsApi.list()
     const projects = projectsRes.data.items || projectsRes.data
     if (projects.length > 0) {
+      currentProjectId.value = projects[0].id
       const typesRes = await taskSettingsApi.getTypes(projects[0].id)
       taskTypes.value = typesRes.data.filter(t => t.is_active)
+      jqlStore.fetchSavedFilters(projects[0].id)
     }
   } catch { taskTypes.value = [] }
 }
@@ -339,10 +438,124 @@ onMounted(async () => {
 </script>
 
 <style scoped>
+.toolbar-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.view-toggle {
+  display: flex;
+  gap: 2px;
+  background: var(--bg-card);
+  border-radius: 8px;
+  padding: 2px;
+}
+
+.toggle-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 28px;
+  border: none;
+  background: none;
+  color: var(--text-secondary);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.toggle-btn.active {
+  background: var(--accent);
+  color: white;
+}
+
+.toggle-btn:hover:not(.active) { background: var(--bg-secondary); }
+
+/* Task List View */
+.task-list {
+  background: var(--bg-card);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.empty-list {
+  padding: 40px;
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+.task-list-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--bg-secondary);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.task-list-row:hover { background: var(--bg-secondary); }
+.task-list-row:last-child { border-bottom: none; }
+
+.row-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+}
+
+.task-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 14px;
+}
+
+.row-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.status-pill {
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 500;
+  color: white;
+}
+
+.status-pill.legacy {
+  background: var(--text-secondary);
+}
+
+.priority-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.priority-dot.high { background: #f59e0b; }
+.priority-dot.medium { background: #3b82f6; }
+.priority-dot.low { background: #6b7280; }
+
+.assignee-pill {
+  font-size: 12px;
+  color: var(--text-secondary);
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .type-tabs {
   display: flex;
   gap: 4px;
-  margin-bottom: 16px;
   overflow-x: auto;
   padding-bottom: 2px;
 }


### PR DESCRIPTION
## Summary
- Lark-based JQL parser with full Jira-compatible syntax (AND/OR/NOT, IN, WAS, CHANGED, IS EMPTY, ORDER BY, relative dates, functions)
- AST → SQLAlchemy compiler with FK-lookup caching
- API endpoints: `GET /tasks?jql=`, `/tasks/jql-validate`, `/tasks/jql-suggest`, `/tasks/jql-ai` (Claude API), `/saved-filters/*` CRUD
- Frontend: JQLBar component (validation, autocomplete, AI translate), SavedFilters sidebar, Board/List view toggle
- 54 tests (parser + compiler), migration for saved_filters table

## Test plan
- [ ] Проверить парсинг JQL запросов через `/tasks/jql-validate`
- [ ] Проверить фильтрацию через `GET /tasks?jql=status = todo`
- [ ] Проверить автодополнение через `/tasks/jql-suggest`
- [ ] Проверить сохранение/загрузку фильтров
- [ ] Проверить переключение Board/List в UI
- [ ] Запустить `pytest tests/jql/ -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)